### PR TITLE
refactor(ColumnData): Add implementation for f64() casting and string Display format

### DIFF
--- a/twinleaf-tools/src/bin/tio-monitor.rs
+++ b/twinleaf-tools/src/bin/tio-monitor.rs
@@ -123,18 +123,19 @@ impl ColumnFormatter {
         desc_width: usize,
     ) -> std::io::Result<()> {
         use data::ColumnData;
-        let (fval, fmtval) = match col.value {
-            ColumnData::Int(x) => (x as f64, format!("{:10}      ", x)),
-            ColumnData::UInt(x) => (x as f64, format!("{:10}      ", x)),
-            ColumnData::Float(x) => (
-                x,
+
+        let fval = col.value.try_as_f64().unwrap_or(f64::NAN);
+        let fmtval = match col.value {
+            ColumnData::Int(x) => format!("{:10}      ", x),
+            ColumnData::UInt(x) => format!("{:10}      ", x),
+            ColumnData::Float(x) => {
                 if x.is_nan() {
                     format!("{:10}      ", x)
                 } else {
                     format!("{:15.4} ", x)
-                },
-            ),
-            ColumnData::Unknown => (f64::NAN, format!("{:>15} ", "unsupported")),
+                }
+            }
+            ColumnData::Unknown => format!("{:>15} ", "unsupported"),
         };
 
         stdout.queue(cursor::MoveToNextLine(1))?;

--- a/twinleaf/src/data/sample.rs
+++ b/twinleaf/src/data/sample.rs
@@ -22,6 +22,17 @@ impl ColumnData {
     }
 }
 
+impl std::fmt::Display for ColumnData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            ColumnData::Int(x) => write!(f, "{}", x),
+            ColumnData::UInt(x) => write!(f, "{}", x),
+            ColumnData::Float(x) => write!(f, "{}", x),
+            ColumnData::Unknown => write!(f, "?"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Column {
     pub value: ColumnData,

--- a/twinleaf/src/data/sample.rs
+++ b/twinleaf/src/data/sample.rs
@@ -122,17 +122,7 @@ impl std::fmt::Display for Sample {
             self.timestamp_end()
         )?;
         for col in &self.columns {
-            write!(
-                f,
-                " {}: {}",
-                col.desc.name,
-                match col.value {
-                    ColumnData::Int(x) => format!("{}", x),
-                    ColumnData::UInt(x) => format!("{}", x),
-                    ColumnData::Float(x) => format!("{}", x),
-                    ColumnData::Unknown => "?".to_string(),
-                }
-            )?;
+            write!(f, " {}: {}", col.desc.name, col.value)?;
         }
         write!(f, " [#{}]", self.n)
     }

--- a/twinleaf/src/data/sample.rs
+++ b/twinleaf/src/data/sample.rs
@@ -11,6 +11,17 @@ pub enum ColumnData {
     Unknown,
 }
 
+impl ColumnData {
+    pub fn try_as_f64(&self) -> Option<f64> {
+        match *self {
+            ColumnData::Int(i) => Some(i as f64),
+            ColumnData::UInt(u) => Some(u as f64),
+            ColumnData::Float(f) => Some(f),
+            ColumnData::Unknown => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Column {
     pub value: ColumnData,


### PR DESCRIPTION
## Motivation 

The core change consists of adding two implementations to `ColumnData` as a convenience change for `Trendline` to guarantee `ColumnData` would be cast as floating point number.

```Rust
// Provides a way to get a consistent numeric representation.
pub fn try_as_f64(&self) -> Option<f64> { ... }

// Provides a way to get a string representation.
impl std::fmt::Display for ColumnData { ... }
```


## Changes
- a55963187ae12a886b48575136dc39e4e20036f4 Update `tio-monitor` to first get the value as a `f64()` before formatting for display. 
    - Notably, I still `unwrap_or()` to guarantee it is a `f64::NAN`. It may be worth discussing if `ColumnData::Unknown` should return `None` or implicitly `f64::NAN`
- 1ba8c4507b9b4af10fddc6f871a9102beae21fda Update `tio-tool` to use `fmt::Display` instead of `match_value()`
    - This also required refactoring `log_csv()`
- 0f08381c418f31f2347e55d289f8cbe19eb8e377 Change `Sample`'s `fmt::Display` to use `ColumnData`'s `fmt::Display`


In general, the `log_csv()` is the most involved change but is conceptually straightforward. Instead of manually checking whether the current column's value was equal to the last column's, collect them all into a row using an iterator and append commas between elements with `join()` . This also resolved the bug where if a prior column's value being equal to the last column's would not have a comma separating them.

## How to Test
Verify that `log_csv()` still works properly. I collected data and converted to a .csv using the main branch's implementation and then verified it had no difference when using the updated version.

Verify that `tio-monitor` still works properly. I visually verified that `tio-monitor` continues to display data streams.