### PR TITLE
refactor(Device): Add error propagation and remove .unwraps() where applicable

### DIFF
--- a/twinleaf-tools/src/bin/tio-tool.rs
+++ b/twinleaf-tools/src/bin/tio-tool.rs
@@ -385,12 +385,20 @@ fn data_dump(args: &[String]) -> Result<(), ()> {
     let (_matches, root, route) = tio_parseopts(&opts, args);
 
     let proxy = proxy::Interface::new(&root);
-    let mut device = twinleaf::Device::open(&proxy, route);
+    let mut device = twinleaf::Device::open(&proxy, route).map_err(|e| {
+        eprintln!("Failed to open device: {:?}", e);
+    })?;
 
     loop {
-        print_sample(&device.next());
+        match device.next() {
+            Ok(sample) => print_sample(&sample),
+            Err(e) => {
+                eprintln!("\nDevice error: {:?}. Exiting.", e);
+                break;
+            }
+        }
     }
-    // Ok(())
+    Ok(())
 }
 
 fn log(args: &[String]) -> Result<(), ()> {

--- a/twinleaf-tools/src/bin/tio-tool.rs
+++ b/twinleaf-tools/src/bin/tio-tool.rs
@@ -347,9 +347,14 @@ fn meta_dump(args: &[String]) -> Result<(), ()> {
     let (_matches, root, route) = tio_parseopts(&opts, args);
 
     let proxy = proxy::Interface::new(&root);
-    let mut device = twinleaf::Device::open(&proxy, route);
+    let mut device = twinleaf::Device::open(&proxy, route).map_err(|e| {
+        eprintln!("Failed to open device: {:?}", e);
+    })?;
 
-    let meta = device.get_metadata();
+    let meta = device.get_metadata().map_err(|e| {
+        eprintln!("Failed to get metadata: {:?}", e);
+    })?;
+
     println!("{:?}", meta.device);
     for (_id, stream) in meta.streams {
         println!("{:?}", stream.stream);
@@ -443,9 +448,14 @@ fn log_metadata(args: &[String]) -> Result<(), ()> {
     }
 
     let proxy = proxy::Interface::new(&root);
-    let mut device = twinleaf::Device::open(&proxy, route);
+    let mut device = twinleaf::Device::open(&proxy, route).map_err(|e| {
+        eprintln!("Failed to open device: {:?}", e);
+    })?;
 
-    let meta = device.get_metadata();
+    let meta = device.get_metadata().map_err(|e| {
+        eprintln!("Failed to get metadata: {:?}", e);
+    })?;
+    
     let output_path = if let Some(path) = matches.opt_str("f") {
         path
     } else {

--- a/twinleaf/src/device/mod.rs
+++ b/twinleaf/src/device/mod.rs
@@ -202,7 +202,9 @@ impl Device {
         Ok(full_reply)
     }
 
-    pub fn get_multi_str(&mut self, name: &str) -> String {
-        String::from_utf8_lossy(&self.get_multi(name)).to_string()
+    pub fn get_multi_str(&mut self, name: &str) -> Result<String, tio::proxy::RpcError> {
+        let reply_bytes = self.get_multi(name)?;
+        let result_string = String::from_utf8_lossy(&reply_bytes).to_string();
+        Ok(result_string)
     }
 }


### PR DESCRIPTION
## Motivation
Previously, `Trendline` was forced into using unwinds due to the `panic!()` from both `try_next()` and `drain()`. 
```Rust
let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
     device.drain()
}));
```
This seems to have been implemented because a `Device` was expected to die alongside the proxy connection. This assumption seems to be counterproductive for a stateful application like `Trendline`. 

In `Trendline`, a `Device` is associated to its cached metadata and RPC values. Instead of entirely terminating the cache, a `RecvError::ProxyDisconnected` should prompt a reconnect attempt for that specific device's port and subsequent rebuilding of that device's cache.

Keep in mind, this error is distinct from the entire root proxy being disconnected. An example is in the case of failing to drain the device fast enough. When not draining fast enough, the proxy would terminate the device's port because the crossbeam channel filled up. Although this is developer error, where `Trendline` had writer starvation (necessitating the separation of `Sample` draining and writing to a buffer), it would be useful to allow a developer to decide what to do with the `ProxyDisconnected`.

## Changes
- (726cdab55b0d6770253d90e94b276c9ced1d8b71 bf2e6b57c85675ac60ce5126291732f737e2de2a) Modify the `Device` module to return `proxy::RpcError` for many functions, and `proxy::SendError` or `proxy::PortError` where appropriate
- (06fa523c3e16cfaadc68baf765d5711876a58234 8ae6a3733d6a86259b02001a8caebb80aa38d0fe) Update `tio-tool` to print errors from the above changes
- (d8cc2d3837079c4fcffdcb4f78ed33e909b4a219) Update `tio-monitor` to `.expect()` a `Device` connection and otherwise match case over the `try_next()` results.
    - There were also changes to use `take_hook()` to propagate the original `panic` the application might emit and simplifications to escape key handling 
    
## How to Test

Verify that the behavior of `meta_dump()`, `log_metadata()`, and `data_dump()` went unchanged. They seemed to work fine, as I only changed the commands surrounding their device connection and metadata error handling.

Verify that tio-monitor still works properly. I visually verified nothing broke and that the escape keys (q, esc, Ctrl+C), worked fine.

